### PR TITLE
Use quotes to include local headers

### DIFF
--- a/logger/Logger.cxx
+++ b/logger/Logger.cxx
@@ -5,7 +5,7 @@
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
  *                  copied verbatim in the file "LICENSE"                       *
  ********************************************************************************/
-#include <Logger.h>
+#include "Logger.h"
 
 #include <iostream>
 #include <ostream>


### PR DESCRIPTION
In general angular brackets are used for external headers, while quotes are used for internal ones. Is there any particular reason not to follow the conventions? While this is admittedly left to the compiler implementor by the standard, some implementations, like gcc, do have a peculiar behavior for the two kind of `include` and the current solution might end up including something unwanted, especially given the quite "common" name (Logger) used.