### PR TITLE
Allow use after static destruction took place

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build/
+.vscode

--- a/logger/Logger.h
+++ b/logger/Logger.h
@@ -335,6 +335,10 @@ class Logger
 
     virtual ~Logger() noexcept(false);
 
+    // protection for use after static destruction took place
+    static bool fIsDestructed;
+    static struct DestructionHelper { ~DestructionHelper() { Logger::fIsDestructed = true; }} fDestructionHelper;
+
   private:
     LogMetaData fMetaData;
 


### PR DESCRIPTION
This patch allows the Logger macro to be used after the static members of the Logger class have been destroyed. Such a case can happen when another object with a static lifetime calls the macro, after the Logger static members have already been destroyed. With this patch this will produce a simple unformatted output.

Potentially more meta information can be also allowed in such a case, if we use only POD static members. But as a first step this will print just the message with a prefix notice, without file logging, formatting or custom sinks.