### PR TITLE
Support fmt >=6.0.0

### DIFF
--- a/logger/Logger.cxx
+++ b/logger/Logger.cxx
@@ -7,7 +7,11 @@
  ********************************************************************************/
 #include "Logger.h"
 
+#if FMT_VERSION < 60000
 #include <fmt/time.h>
+#else
+#include <fmt/chrono.h>
+#endif
 
 #include <cstdio> // printf
 #include <iostream>


### PR DESCRIPTION
The currently bundled fmt is at version 5.3.0, which has it's time formatting that we use in `time.h`. It also provides `chrono.h`, but that does not contain the features we need. fmt >=6 removed the `time.h` and has all time related features in `chrono.h`. 
A version check will allow to be compatible with both versions of the library.