### PR TITLE
Provide implementation of stringstream

### DIFF
--- a/logger/Logger.h
+++ b/logger/Logger.h
@@ -347,6 +347,10 @@ class Logger
 
 } // namespace fair
 
+// Instantiate string stream, this is needed since Logger.cxx will create the symbol only for the CXXSTD used to compile FairLogger
+// When other packages include this header while using a different CXXSTD, the symbol for that CXXSTD will be missing.
+template class std::basic_stringstream<char, std::char_traits<char>, std::allocator<char> >;
+
 #define IMP_CONVERTTOSTRING(s) # s
 #define CONVERTTOSTRING(s) IMP_CONVERTTOSTRING(s)
 


### PR DESCRIPTION
This is a fix required to use fairlogger from libraries not compiled with the C++ standard used for fair logger.

The problem is that FairLogger/Logger.h requires stringstream functions, but since it doesn't create a stringstream itself, it doesn't instantiate the class. Only Logger.cxx instantiates it. Different C++ standards have different ABIs for stringstream. This break in the following case (for instance):
- FairLogger is compiled with C++17
- Another library (in my case the CUDA tracking library of O2) is compiled with C++ 14.
- This other library doesn't isntantiate stringstream by itself, but it includes Logger.h
- In that case, at linking the implementation of the C++14 stringstream will be required, but it will not be available, since fairlogger.so has the C++17 implementation and the other library has no implementation.
This fix makes sure that the correct implementation is always available, because simply including the header will always instantiate it for the correct C++ standard.

I agree this is not a nice fix, but to be honest, I see no other way of fixing this.

@ironMann : for reference, this is a very similar problem to what I reported for DataDistribution, but this is now the full explanation.