### PR TITLE
Exchange the meaning of LOGP and LOGF

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ All log calls go through the provided LOG(severity) macro. Output through this m
 A number of additional logging macros are provided:
 
 - `LOGV(severity, verbosity)` Log the line with the provided verbosity, e.g. `LOG(info, veryhigh) << "abcd";`
-- `LOGF(severity, ...)` The arguments are given to `fmt::format` and the result is logged, e.g. `LOGF(info, "Hello {}!", "world");`
-- `LOGP(severity, ...)` The arguments are given to `fmt::printf` and the result is logged, e.g. `LOGP(info, "Hello %s!", "world");`
+- `LOGF(severity, ...)` The arguments are given to `fmt::printf`, which formats the string using a [printf syntax](https://fmt.dev/dev/api.html#printf-formatting) and the result is logged, e.g. `LOGF(info, "Hello %s!", "world");`
+- `LOGP(severity, ...)` The arguments are given to `fmt::format`, which formats the string using a [Python-like syntax](https://fmt.dev/dev/syntax.html) and the result is logged, e.g. `LOGP(info, "Hello {}!", "world");`
 - `LOGN(severity)` Logs an empty line, e.g. `LOGN(info);`
 - `LOG_IF(severity, condition)` Logs the line if the provided condition if true
 - `LOGD(severity, file, line, f)` Logs the line with the provided file, line and function parameters (only if the active verbosity allows it).

--- a/logger/Logger.h
+++ b/logger/Logger.h
@@ -418,8 +418,8 @@ class Logger
             fair::Logger(fair::Severity::severity, fair::Verbosity::verbosity, MSG_ORIGIN)
 
 // Log with fmt- or printf-like formatting
-#define FAIR_LOGF(severity, ...) LOG(severity) << fmt::format(__VA_ARGS__)
-#define FAIR_LOGP(severity, ...) LOG(severity) << fmt::sprintf(__VA_ARGS__)
+#define FAIR_LOGP(severity, ...) LOG(severity) << fmt::format(__VA_ARGS__)
+#define FAIR_LOGF(severity, ...) LOG(severity) << fmt::sprintf(__VA_ARGS__)
 
 // Log an empty line
 #define FAIR_LOGN(severity) \

--- a/test/loggerTest.cxx
+++ b/test/loggerTest.cxx
@@ -190,8 +190,8 @@ int main()
     cout << "cout: setting severity to 'trace'" << endl;
     Logger::SetConsoleSeverity(Severity::trace);
 
-    LOGF(info, "Hello {} {}!", "world", ":-)");
-    LOGP(info, "Hello %s %s!", "world", ":-)");
+    LOGP(info, "Hello {} {}!", "world", ":-)");
+    LOGF(info, "Hello %s %s!", "world", ":-)");
 
     cout << "cout: setting verbosity to 'high'" << endl;
     Logger::SetVerbosity(Verbosity::high);


### PR DESCRIPTION
LOG`P` for `P`ython-like syntax and LOG`F` for print`f` fits better than LOG`P` for `p`rintf and LOG`F` for `f`mt::`f`ormat, because former aligns to a type of formatting rather than just a function name.

@ktf @davidrohr alisw/alidist#2309.

