### PR TITLE
bundled fmt: Fix target_compile_feature

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ else()
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/logger/bundled>
     $<INSTALL_INTERFACE:${PROJECT_INSTALL_BUNDLEDINCDIR}>
   )
-  target_compile_features(fmt PUBLIC cxx_std_11)
+  target_compile_features(fmt INTERFACE cxx_std_11)
   target_compile_definitions(fmt INTERFACE FMT_HEADER_ONLY)
   target_link_libraries(FairLogger PUBLIC fmt)
 endif()


### PR DESCRIPTION
When using the bundled fmt, the declared "INTERFACE" target can only declare INTERFACE compile features via `target_compile_feature`.