### PR TITLE
Add 'alarm' and 'important' severities

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ add_library(FairLogger
   logger/Logger.cxx
   logger/Logger.h
 )
-target_compile_features(FairLogger PUBLIC cxx_std_11)
+target_compile_features(FairLogger PUBLIC cxx_std_14)
 
 if(USE_BOOST_PRETTY_FUNCTION)
   target_link_libraries(FairLogger PUBLIC Boost::boost)

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ where severity level is one of the following:
 "info",
 "state",
 "warn",
+"important",
+"alarm",
 "error",
 "fatal",
 ```

--- a/cmake/FairLoggerLib.cmake
+++ b/cmake/FairLoggerLib.cmake
@@ -94,7 +94,7 @@ macro(set_fairlogger_defaults)
   endif()
 
   # Handle C++ standard level
-  set(PROJECT_MIN_CXX_STANDARD 11)
+  set(PROJECT_MIN_CXX_STANDARD 14)
   if(CMAKE_CXX_STANDARD LESS PROJECT_MIN_CXX_STANDARD)
     message(FATAL_ERROR "A minimum CMAKE_CXX_STANDARD of ${PROJECT_MIN_CXX_STANDARD} is required.")
   endif()

--- a/logger/Logger.cxx
+++ b/logger/Logger.cxx
@@ -63,33 +63,35 @@ const unordered_map<string, Verbosity> Logger::fVerbosityMap =
 
 const unordered_map<string, Severity> Logger::fSeverityMap =
 {
-    { "nolog",   Severity::nolog  },
-    { "NOLOG",   Severity::nolog  },
-    { "error",   Severity::error  },
-    { "ERROR",   Severity::error  },
-    { "warn",    Severity::warn   },
-    { "WARN",    Severity::warn   },
-    { "warning", Severity::warn   },
-    { "WARNING", Severity::warn   },
-    { "state",   Severity::state  },
-    { "STATE",   Severity::state  },
-    { "info",    Severity::info   },
-    { "INFO",    Severity::info   },
-    { "debug",   Severity::debug  },
-    { "DEBUG",   Severity::debug  },
-    { "debug1",  Severity::debug1 },
-    { "DEBUG1",  Severity::debug1 },
-    { "debug2",  Severity::debug2 },
-    { "DEBUG2",  Severity::debug2 },
-    { "debug3",  Severity::debug3 },
-    { "DEBUG3",  Severity::debug3 },
-    { "debug4",  Severity::debug4 },
-    { "DEBUG4",  Severity::debug4 },
-    { "trace",   Severity::trace  },
-    { "TRACE",   Severity::trace  }
+    { "nolog",     Severity::nolog     },
+    { "NOLOG",     Severity::nolog     },
+    { "error",     Severity::error     },
+    { "ERROR",     Severity::error     },
+    { "alarm",     Severity::alarm     },
+    { "important", Severity::important },
+    { "warn",      Severity::warn      },
+    { "WARN",      Severity::warn      },
+    { "warning",   Severity::warn      },
+    { "WARNING",   Severity::warn      },
+    { "state",     Severity::state     },
+    { "STATE",     Severity::state     },
+    { "info",      Severity::info      },
+    { "INFO",      Severity::info      },
+    { "debug",     Severity::debug     },
+    { "DEBUG",     Severity::debug     },
+    { "debug1",    Severity::debug1    },
+    { "DEBUG1",    Severity::debug1    },
+    { "debug2",    Severity::debug2    },
+    { "DEBUG2",    Severity::debug2    },
+    { "debug3",    Severity::debug3    },
+    { "DEBUG3",    Severity::debug3    },
+    { "debug4",    Severity::debug4    },
+    { "DEBUG4",    Severity::debug4    },
+    { "trace",     Severity::trace     },
+    { "TRACE",     Severity::trace     }
 };
 
-const array<string, 12> Logger::fSeverityNames =
+const array<string, 14> Logger::fSeverityNames =
 {
     {
         "NOLOG",
@@ -102,6 +104,8 @@ const array<string, 12> Logger::fSeverityNames =
         "INFO",
         "STATE",
         "WARN",
+        "IMPORTANT",
+        "ALARM",
         "ERROR",
         "FATAL"
     }
@@ -278,19 +282,21 @@ void Logger::LogEmptyLine()
 string Logger::GetColoredSeverityString(Severity severity)
 {
     switch (severity) {
-        case Severity::nolog:  return "\033[01;39mNOLOG\033[0m";  break;
-        case Severity::fatal:  return "\033[01;31mFATAL\033[0m";  break;
-        case Severity::error:  return "\033[01;31mERROR\033[0m";  break;
-        case Severity::warn:   return "\033[01;33mWARN\033[0m";   break;
-        case Severity::state:  return "\033[01;35mSTATE\033[0m";  break;
-        case Severity::info:   return "\033[01;32mINFO\033[0m";   break;
-        case Severity::debug:  return "\033[01;34mDEBUG\033[0m";  break;
-        case Severity::debug1: return "\033[01;34mDEBUG1\033[0m"; break;
-        case Severity::debug2: return "\033[01;34mDEBUG2\033[0m"; break;
-        case Severity::debug3: return "\033[01;34mDEBUG3\033[0m"; break;
-        case Severity::debug4: return "\033[01;34mDEBUG4\033[0m"; break;
-        case Severity::trace:  return "\033[01;36mTRACE\033[0m";  break;
-        default:               return "UNKNOWN";                  break;
+        case Severity::nolog:     return "\033[01;39mNOLOG\033[0m";     break;
+        case Severity::fatal:     return "\033[01;31mFATAL\033[0m";     break;
+        case Severity::error:     return "\033[01;31mERROR\033[0m";     break;
+        case Severity::alarm:     return "\033[01;33mALARM\033[0m";     break;
+        case Severity::important: return "\033[01;32mIMPORTANT\033[0m"; break;
+        case Severity::warn:      return "\033[01;33mWARN\033[0m";      break;
+        case Severity::state:     return "\033[01;35mSTATE\033[0m";     break;
+        case Severity::info:      return "\033[01;32mINFO\033[0m";      break;
+        case Severity::debug:     return "\033[01;34mDEBUG\033[0m";     break;
+        case Severity::debug1:    return "\033[01;34mDEBUG1\033[0m";    break;
+        case Severity::debug2:    return "\033[01;34mDEBUG2\033[0m";    break;
+        case Severity::debug3:    return "\033[01;34mDEBUG3\033[0m";    break;
+        case Severity::debug4:    return "\033[01;34mDEBUG4\033[0m";    break;
+        case Severity::trace:     return "\033[01;36mTRACE\033[0m";     break;
+        default:                  return "UNKNOWN";                     break;
     }
 }
 

--- a/logger/Logger.h
+++ b/logger/Logger.h
@@ -68,19 +68,19 @@ enum class Severity : int
     // aliases
     warning = warn,
     // backwards-compatibility
-    NOLOG = nolog,
-    TRACE = trace,
-    DEBUG4 = debug4,
-    DEBUG3 = debug3,
-    DEBUG2 = debug2,
-    DEBUG1 = debug1,
-    DEBUG = debug,
-    INFO = info,
-    STATE = state,
-    WARNING = warn,
-    WARN = warn,
-    ERROR = error,
-    FATAL = fatal
+    NOLOG   [[deprecated("Use 'nolog' instead")]]   = nolog,
+    TRACE   [[deprecated("Use 'trace' instead")]]   = trace,
+    DEBUG4  [[deprecated("Use 'debug4' instead")]]  = debug4,
+    DEBUG3  [[deprecated("Use 'debug3' instead")]]  = debug3,
+    DEBUG2  [[deprecated("Use 'debug2' instead")]]  = debug2,
+    DEBUG1  [[deprecated("Use 'debug1' instead")]]  = debug1,
+    DEBUG   [[deprecated("Use 'debug' instead")]]   = debug,
+    INFO    [[deprecated("Use 'info' instead")]]    = info,
+    STATE   [[deprecated("Use 'state' instead")]]   = state,
+    WARNING [[deprecated("Use 'warning' instead")]] = warn,
+    WARN    [[deprecated("Use 'warn' instead")]]    = warn,
+    ERROR   [[deprecated("Use 'error' instead")]]   = error,
+    FATAL   [[deprecated("Use 'fatal' instead")]]   = fatal
 };
 
 // verbosity levels:

--- a/logger/Logger.h
+++ b/logger/Logger.h
@@ -61,9 +61,13 @@ enum class Severity : int
     info = 7,
     state = 8,
     warn = 9,
-    error = 10,
-    fatal = 11,
-    // backwards-compatibility:
+    important = 10,
+    alarm = 11,
+    error = 12,
+    fatal = 13,
+    // aliases
+    warning = warn,
+    // backwards-compatibility
     NOLOG = nolog,
     TRACE = trace,
     DEBUG4 = debug4,
@@ -74,7 +78,6 @@ enum class Severity : int
     INFO = info,
     STATE = state,
     WARNING = warn,
-    warning = warn,
     WARN = warn,
     ERROR = error,
     FATAL = fatal
@@ -319,7 +322,7 @@ class Logger
 
     static const std::unordered_map<std::string, Verbosity> fVerbosityMap;
     static const std::unordered_map<std::string, Severity> fSeverityMap;
-    static const std::array<std::string, 12> fSeverityNames;
+    static const std::array<std::string, 14> fSeverityNames;
     static const std::array<std::string, 9> fVerbosityNames;
 
     // protection for use after static destruction took place

--- a/test/cycle.cxx
+++ b/test/cycle.cxx
@@ -38,7 +38,7 @@ int main()
         Logger::SetConsoleSeverity(Severity::fatal);
         cout << "initial severity >" << Logger::GetConsoleSeverity() << "<" << endl << endl;
 
-        array<Severity, 12> severitiesUp{{ Severity::nolog, Severity::trace, Severity::debug4, Severity::debug3, Severity::debug2, Severity::debug1, Severity::debug, Severity::info, Severity::state, Severity::warn, Severity::error, Severity::fatal }};
+        array<Severity, 14> severitiesUp{{ Severity::nolog, Severity::trace, Severity::debug4, Severity::debug3, Severity::debug2, Severity::debug1, Severity::debug, Severity::info, Severity::state, Severity::warn, Severity::important, Severity::alarm, Severity::error, Severity::fatal }};
 #ifdef FAIR_MIN_SEVERITY
         for (unsigned int i = static_cast<int>(Severity::FAIR_MIN_SEVERITY); i < severitiesUp.size(); ++i) {
 #else
@@ -57,7 +57,7 @@ int main()
         Logger::SetConsoleSeverity(Severity::fatal);
         cout << "initial severity >" << Logger::GetConsoleSeverity() << "<" << endl << endl;
 
-        array<Severity, 12> severitiesDown{{ Severity::error, Severity::warn, Severity::state, Severity::info, Severity::debug, Severity::debug1, Severity::debug2, Severity::debug3, Severity::debug4, Severity::trace, Severity::nolog, Severity::fatal }};
+        array<Severity, 14> severitiesDown{{ Severity::error, Severity::alarm, Severity::important, Severity::warn, Severity::state, Severity::info, Severity::debug, Severity::debug1, Severity::debug2, Severity::debug3, Severity::debug4, Severity::trace, Severity::nolog, Severity::fatal }};
 #ifdef FAIR_MIN_SEVERITY
         for (unsigned int i = 0; i < severitiesDown.size() - static_cast<int>(Severity::FAIR_MIN_SEVERITY) - 1; ++i) {
 #else

--- a/test/logger.cxx
+++ b/test/logger.cxx
@@ -17,18 +17,20 @@ void printEverySeverity()
 {
     static int i = 1;
 
-    LOG(nolog)  << "nolog message, counter: "   << i++;
-    LOG(trace)  << "trace message, counter: "   << i++;
-    LOG(debug4) << "debug4 message, counter: "  << i++;
-    LOG(debug3) << "debug3 message, counter: "  << i++;
-    LOG(debug2) << "debug2 message, counter: "  << i++;
-    LOG(debug1) << "debug1 message, counter: "  << i++;
-    LOG(debug)  << "debug message, counter: "   << i++;
-    LOG(info)   << "info message, counter: "    << i++;
-    LOG(state)  << "state message, counter: "   << i++;
-    LOG(warn)   << "warning message, counter: " << i++;
-    LOG(error)  << "error message, counter: "   << i++;
-    LOG(fatal)  << "fatal message, counter: "   << i++;
+    LOG(nolog)     << "nolog message, counter: "     << i++;
+    LOG(trace)     << "trace message, counter: "     << i++;
+    LOG(debug4)    << "debug4 message, counter: "    << i++;
+    LOG(debug3)    << "debug3 message, counter: "    << i++;
+    LOG(debug2)    << "debug2 message, counter: "    << i++;
+    LOG(debug1)    << "debug1 message, counter: "    << i++;
+    LOG(debug)     << "debug message, counter: "     << i++;
+    LOG(info)      << "info message, counter: "      << i++;
+    LOG(state)     << "state message, counter: "     << i++;
+    LOG(warn)      << "warning message, counter: "   << i++;
+    LOG(important) << "important message, counter: " << i++;
+    LOG(alarm)     << "alarm message, counter: "     << i++;
+    LOG(error)     << "error message, counter: "     << i++;
+    LOG(fatal)     << "fatal message, counter: "     << i++;
 }
 
 void printAllVerbositiesWithSeverity(Severity sev)

--- a/test/nolog.cxx
+++ b/test/nolog.cxx
@@ -13,17 +13,19 @@ using namespace fair;
 
 void printEverySeverity()
 {
-    LOG(nolog)  << "nolog message, counter: ";
-    LOG(trace)  << "trace message, counter: ";
-    LOG(debug4) << "debug4 message, counter: ";
-    LOG(debug3) << "debug3 message, counter: ";
-    LOG(debug2) << "debug2 message, counter: ";
-    LOG(debug1) << "debug1 message, counter: ";
-    LOG(debug)  << "debug message, counter: ";
-    LOG(info)   << "info message, counter: " ;
-    LOG(state)  << "state message, counter: ";
-    LOG(warn)   << "warning message, counter: ";
-    LOG(error)  << "error message, counter: ";
+    LOG(nolog)     << "nolog message, counter: ";
+    LOG(trace)     << "trace message, counter: ";
+    LOG(debug4)    << "debug4 message, counter: ";
+    LOG(debug3)    << "debug3 message, counter: ";
+    LOG(debug2)    << "debug2 message, counter: ";
+    LOG(debug1)    << "debug1 message, counter: ";
+    LOG(debug)     << "debug message, counter: ";
+    LOG(info)      << "info message, counter: ";
+    LOG(state)     << "state message, counter: ";
+    LOG(warn)      << "warning message, counter: ";
+    LOG(important) << "important message, counter: ";
+    LOG(alarm)     << "alarm message, counter: ";
+    LOG(error)     << "error message, counter: ";
 }
 
 void silentlyPrintAllVerbositiesWithSeverity(Severity sev)

--- a/test/severity.cxx
+++ b/test/severity.cxx
@@ -20,18 +20,20 @@ using namespace fair::logger::test;
 
 uint32_t printEverySeverity(uint32_t i)
 {
-    LOG(nolog)  << "nolog message, counter: "   << i++;
-    LOG(trace)  << "trace message, counter: "   << i++;
-    LOG(debug4) << "debug4 message, counter: "  << i++;
-    LOG(debug3) << "debug3 message, counter: "  << i++;
-    LOG(debug2) << "debug2 message, counter: "  << i++;
-    LOG(debug1) << "debug1 message, counter: "  << i++;
-    LOG(debug)  << "debug message, counter: "   << i++;
-    LOG(info)   << "info message, counter: "    << i++;
-    LOG(state)  << "state message, counter: "   << i++;
-    LOG(warn)   << "warning message, counter: " << i++;
-    LOG(error)  << "error message, counter: "   << i++;
-    LOG(fatal)  << "fatal message, counter: "   << i++;
+    LOG(nolog)     << "nolog message, counter: "     << i++;
+    LOG(trace)     << "trace message, counter: "     << i++;
+    LOG(debug4)    << "debug4 message, counter: "    << i++;
+    LOG(debug3)    << "debug3 message, counter: "    << i++;
+    LOG(debug2)    << "debug2 message, counter: "    << i++;
+    LOG(debug1)    << "debug1 message, counter: "    << i++;
+    LOG(debug)     << "debug message, counter: "     << i++;
+    LOG(info)      << "info message, counter: "      << i++;
+    LOG(state)     << "state message, counter: "     << i++;
+    LOG(warn)      << "warning message, counter: "   << i++;
+    LOG(important) << "important message, counter: " << i++;
+    LOG(alarm)     << "alarm message, counter: "     << i++;
+    LOG(error)     << "error message, counter: "     << i++;
+    LOG(fatal)     << "fatal message, counter: "     << i++;
 
     return i;
 }
@@ -45,7 +47,7 @@ void CheckSeverity(Severity severity)
 
     for (uint32_t i = 0; i < Logger::fSeverityNames.size(); ++i) {
         if (sev == Severity::nolog) {
-            if (i == 11) {
+            if (i == static_cast<int>(fair::Severity::fatal)) {
                 if (!Logger::Logging(static_cast<Severity>(i))) {
                     throw runtime_error(ToStr("expecting to be logging ", Logger::fSeverityNames.at(i), " during ", sev, ", but it is not."));
                 }


### PR DESCRIPTION
- Add two new severities:

~~fatal > error >  **alarm** > warn > state > **important** > info > debug > debug1 > debug2 > debug3 > debug4 > trace~~
EDIT: fatal > error >  **alarm** > **important** > warn > state > info > debug > debug1 > debug2 > debug3 > debug4 > trace

@davidrohr 

Also:
- Bump C++ requirement to 14.
- Deprecate uppercase severity names.