### PR TITLE
Include fmt/ostream.h, needed for on the fly std::ostream usage

### DIFF
--- a/logger/Logger.h
+++ b/logger/Logger.h
@@ -26,6 +26,7 @@
 
 #include <fmt/core.h>
 #include <fmt/printf.h>
+#include <fmt/ostream.h>
 
 #pragma GCC diagnostic pop
 


### PR DESCRIPTION
As of libfmt 8.x, they require the inclusion of `fmt/ostream.h` to use classes that have an ostream operator as arument to fmt::format. This is used in O2, so we either need the include here, or in O2 in `Framework/Logger.h`. I thought in FairLogger would be the more natural place (ping @ktf).