### PR TITLE
Add 'detail' severity between debug and info

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ where severity level is one of the following:
 "debug2",
 "debug1",
 "debug",
+"detail",
 "info",
 "state",
 "warn",

--- a/logger/Logger.cxx
+++ b/logger/Logger.cxx
@@ -78,6 +78,7 @@ const unordered_map<string, Severity> Logger::fSeverityMap =
     { "STATE",     Severity::state     },
     { "info",      Severity::info      },
     { "INFO",      Severity::info      },
+    { "detail",    Severity::detail    },
     { "debug",     Severity::debug     },
     { "DEBUG",     Severity::debug     },
     { "debug1",    Severity::debug1    },
@@ -92,7 +93,7 @@ const unordered_map<string, Severity> Logger::fSeverityMap =
     { "TRACE",     Severity::trace     }
 };
 
-const array<string, 14> Logger::fSeverityNames =
+const array<string, 15> Logger::fSeverityNames =
 {
     {
         "NOLOG",
@@ -102,6 +103,7 @@ const array<string, 14> Logger::fSeverityNames =
         "DEBUG2",
         "DEBUG1",
         "DEBUG",
+        "DETAIL",
         "INFO",
         "STATE",
         "WARN",
@@ -291,6 +293,7 @@ string Logger::GetColoredSeverityString(Severity severity)
         case Severity::warn:      return "\033[01;33mWARN\033[0m";      break;
         case Severity::state:     return "\033[01;35mSTATE\033[0m";     break;
         case Severity::info:      return "\033[01;32mINFO\033[0m";      break;
+        case Severity::detail:    return "\033[01;32mDETAIL\033[0m";    break;
         case Severity::debug:     return "\033[01;34mDEBUG\033[0m";     break;
         case Severity::debug1:    return "\033[01;34mDEBUG1\033[0m";    break;
         case Severity::debug2:    return "\033[01;34mDEBUG2\033[0m";    break;

--- a/logger/Logger.h
+++ b/logger/Logger.h
@@ -59,29 +59,30 @@ enum class Severity : int
     debug2 = 4,
     debug1 = 5,
     debug = 6,
-    info = 7,
-    state = 8,
-    warn = 9,
-    important = 10,
-    alarm = 11,
-    error = 12,
-    fatal = 13,
+    detail = 7,
+    info = 8,
+    state = 9,
+    warn = 10,
+    important = 11,
+    alarm = 12,
+    error = 13,
+    fatal = 14,
     // aliases
     warning = warn,
     // backwards-compatibility
-    NOLOG __attribute__((deprecated("Use LOG(nolog) instead (lowercase severity name)."))) = nolog,
-    FATAL __attribute__((deprecated("Use LOG(fatal) instead (lowercase severity name)."))) = fatal,
-    ERROR __attribute__((deprecated("Use LOG(error) instead (lowercase severity name)."))) = error,
-    WARN __attribute__((deprecated("Use LOG(warn) instead (lowercase severity name)."))) = warn,
+    NOLOG   __attribute__((deprecated("Use LOG(nolog) instead (lowercase severity name)."))) = nolog,
+    FATAL   __attribute__((deprecated("Use LOG(fatal) instead (lowercase severity name)."))) = fatal,
+    ERROR   __attribute__((deprecated("Use LOG(error) instead (lowercase severity name)."))) = error,
+    WARN    __attribute__((deprecated("Use LOG(warn) instead (lowercase severity name)."))) = warn,
     WARNING __attribute__((deprecated("Use LOG(warning) instead (lowercase severity name)."))) = warn,
-    STATE __attribute__((deprecated("Use LOG(state) instead (lowercase severity name)."))) = state,
-    INFO __attribute__((deprecated("Use LOG(info) instead (lowercase severity name)."))) = info,
-    DEBUG __attribute__((deprecated("Use LOG(debug) instead (lowercase severity name)."))) = debug,
-    DEBUG1 __attribute__((deprecated("Use LOG(debug1) instead (lowercase severity name)."))) = debug1,
-    DEBUG2 __attribute__((deprecated("Use LOG(debug2) instead (lowercase severity name)."))) = debug2,
-    DEBUG3 __attribute__((deprecated("Use LOG(debug3) instead (lowercase severity name)."))) = debug3,
-    DEBUG4 __attribute__((deprecated("Use LOG(debug4) instead (lowercase severity name)."))) = debug4,
-    TRACE __attribute__((deprecated("Use LOG(trace) instead (lowercase severity name)."))) = trace
+    STATE   __attribute__((deprecated("Use LOG(state) instead (lowercase severity name)."))) = state,
+    INFO    __attribute__((deprecated("Use LOG(info) instead (lowercase severity name)."))) = info,
+    DEBUG   __attribute__((deprecated("Use LOG(debug) instead (lowercase severity name)."))) = debug,
+    DEBUG1  __attribute__((deprecated("Use LOG(debug1) instead (lowercase severity name)."))) = debug1,
+    DEBUG2  __attribute__((deprecated("Use LOG(debug2) instead (lowercase severity name)."))) = debug2,
+    DEBUG3  __attribute__((deprecated("Use LOG(debug3) instead (lowercase severity name)."))) = debug3,
+    DEBUG4  __attribute__((deprecated("Use LOG(debug4) instead (lowercase severity name)."))) = debug4,
+    TRACE   __attribute__((deprecated("Use LOG(trace) instead (lowercase severity name)."))) = trace
 };
 
 // verbosity levels:
@@ -323,7 +324,7 @@ class Logger
 
     static const std::unordered_map<std::string, Verbosity> fVerbosityMap;
     static const std::unordered_map<std::string, Severity> fSeverityMap;
-    static const std::array<std::string, 14> fSeverityNames;
+    static const std::array<std::string, 15> fSeverityNames;
     static const std::array<std::string, 9> fVerbosityNames;
 
     // protection for use after static destruction took place

--- a/test/cycle.cxx
+++ b/test/cycle.cxx
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2014-2020 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
+ * Copyright (C) 2015-2020 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  *
  *                                                                              *
  *              This software is distributed under the terms of the             *
  *              GNU Lesser General Public Licence (LGPL) version 3,             *
@@ -38,7 +38,7 @@ int main()
         Logger::SetConsoleSeverity(Severity::fatal);
         cout << "initial severity >" << Logger::GetConsoleSeverity() << "<" << endl << endl;
 
-        array<Severity, 14> severitiesUp{{ Severity::nolog, Severity::trace, Severity::debug4, Severity::debug3, Severity::debug2, Severity::debug1, Severity::debug, Severity::info, Severity::state, Severity::warn, Severity::important, Severity::alarm, Severity::error, Severity::fatal }};
+        array<Severity, 15> severitiesUp{{ Severity::nolog, Severity::trace, Severity::debug4, Severity::debug3, Severity::debug2, Severity::debug1, Severity::debug, Severity::detail, Severity::info, Severity::state, Severity::warn, Severity::important, Severity::alarm, Severity::error, Severity::fatal }};
 #ifdef FAIR_MIN_SEVERITY
         for (unsigned int i = static_cast<int>(Severity::FAIR_MIN_SEVERITY); i < severitiesUp.size(); ++i) {
 #else
@@ -57,7 +57,7 @@ int main()
         Logger::SetConsoleSeverity(Severity::fatal);
         cout << "initial severity >" << Logger::GetConsoleSeverity() << "<" << endl << endl;
 
-        array<Severity, 14> severitiesDown{{ Severity::error, Severity::alarm, Severity::important, Severity::warn, Severity::state, Severity::info, Severity::debug, Severity::debug1, Severity::debug2, Severity::debug3, Severity::debug4, Severity::trace, Severity::nolog, Severity::fatal }};
+        array<Severity, 15> severitiesDown{{ Severity::error, Severity::alarm, Severity::important, Severity::warn, Severity::state, Severity::info, Severity::detail, Severity::debug, Severity::debug1, Severity::debug2, Severity::debug3, Severity::debug4, Severity::trace, Severity::nolog, Severity::fatal }};
 #ifdef FAIR_MIN_SEVERITY
         for (unsigned int i = 0; i < severitiesDown.size() - static_cast<int>(Severity::FAIR_MIN_SEVERITY) - 1; ++i) {
 #else

--- a/test/logger.cxx
+++ b/test/logger.cxx
@@ -24,6 +24,7 @@ void printEverySeverity()
     LOG(debug2)    << "debug2 message, counter: "    << i++;
     LOG(debug1)    << "debug1 message, counter: "    << i++;
     LOG(debug)     << "debug message, counter: "     << i++;
+    LOG(detail)    << "detail message, counter: "    << i++;
     LOG(info)      << "info message, counter: "      << i++;
     LOG(state)     << "state message, counter: "     << i++;
     LOG(warn)      << "warning message, counter: "   << i++;

--- a/test/nolog.cxx
+++ b/test/nolog.cxx
@@ -13,19 +13,20 @@ using namespace fair;
 
 void printEverySeverity()
 {
-    LOG(nolog)     << "nolog message, counter: ";
-    LOG(trace)     << "trace message, counter: ";
-    LOG(debug4)    << "debug4 message, counter: ";
-    LOG(debug3)    << "debug3 message, counter: ";
-    LOG(debug2)    << "debug2 message, counter: ";
-    LOG(debug1)    << "debug1 message, counter: ";
-    LOG(debug)     << "debug message, counter: ";
-    LOG(info)      << "info message, counter: ";
-    LOG(state)     << "state message, counter: ";
-    LOG(warn)      << "warning message, counter: ";
-    LOG(important) << "important message, counter: ";
-    LOG(alarm)     << "alarm message, counter: ";
-    LOG(error)     << "error message, counter: ";
+    LOG(nolog)     << "nolog message ";
+    LOG(trace)     << "trace message ";
+    LOG(debug4)    << "debug4 message ";
+    LOG(debug3)    << "debug3 message ";
+    LOG(debug2)    << "debug2 message ";
+    LOG(debug1)    << "debug1 message ";
+    LOG(debug)     << "debug message ";
+    LOG(detail)    << "detail message ";
+    LOG(info)      << "info message ";
+    LOG(state)     << "state message ";
+    LOG(warn)      << "warning message ";
+    LOG(important) << "important message ";
+    LOG(alarm)     << "alarm message ";
+    LOG(error)     << "error message ";
 }
 
 void silentlyPrintAllVerbositiesWithSeverity(Severity sev)

--- a/test/severity.cxx
+++ b/test/severity.cxx
@@ -27,6 +27,7 @@ uint32_t printEverySeverity(uint32_t i)
     LOG(debug2)    << "debug2 message, counter: "    << i++;
     LOG(debug1)    << "debug1 message, counter: "    << i++;
     LOG(debug)     << "debug message, counter: "     << i++;
+    LOG(detail)    << "detail message, counter: "    << i++;
     LOG(info)      << "info message, counter: "      << i++;
     LOG(state)     << "state message, counter: "     << i++;
     LOG(warn)      << "warning message, counter: "   << i++;


### PR DESCRIPTION
Solves #49.
@kft just to double check again - you want a severity between debug and info, right?
Then you will have to change this to `detail`:
https://github.com/AliceO2Group/AliceO2/blob/dev/dependencies/O2CompileFlags.cmake#L96
in order to see the new detail severity.