### PR TITLE
Use DEFAULT_VERSION in get_git_version()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 include(FairLoggerLib)
 include(FairFindPackage2)
 
-get_git_version()
+get_git_version(DEFAULT_VERSION ${PROJECT_VERSION})
 
 project(FairLogger VERSION ${PROJECT_VERSION} LANGUAGES CXX)
 message(STATUS "${BWhite}${PROJECT_NAME}${CR} ${PROJECT_GIT_VERSION} from ${PROJECT_DATE}")


### PR DESCRIPTION
When creating a conda package for FairLogger (as part of investigating moving SHiP software to conda), I noticed that correct versioning relied on being in a git repository of FairLogger. For conda, it is conventional to build from a source tarball.

This PR upstreams a patch I made for conda that allows setting the version via `-DPROJECT_VERSION` as default. When in a git repo, PROJECT_VERSION will then be overridden by the information gotten from git. This makes use of the existing `DEFAULT_VERSION` functionality of `get_git_version`.